### PR TITLE
Introduce an option to configure minimum coverage percantages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,9 +22,11 @@ jobs:
       - name: run build
         run: npm run build
       - name: add and push
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
         run: |
-          git config user.name "${{ secrets.RELEASE_USERNAME }}"
-          git config user.email "${{ secrets.RELEASE_USERNAME }}@users.noreply.github.com"
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
           git add -A
           git commit -m "released new version"
-          git push --force https://${{ secrets.RELEASE_TOKEN }}@github.com/${{ github.repository }}.git $(node -p -e "require('./package.json').version")
+          git push --force https://$GITHUB_ACTOR:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY $(node -p -e "require('./package.json').version")

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ steps:
       GITHUB_CONTEXT: ${{ toJson(github) }}
 ```
 
-There is also an option to adapt the minimum coverage percentage limits that need to be achieved for the build to complete successfully (Defaults to `100`). You can configure an overall minimum by setting the environment variable `COVERAGE` and/or setting specific minimums for the different coverage metrics: `COVERAGE_LINES`, `COVERAGE_STATEMENTS`, `COVERAGE_FUNCTIONS` or `COVERAGE_BRANCHES`.
+There is also an option to adapt the minimum coverage percentage limits that need to be achieved for the build to complete successfully (Defaults to `100`). You can configure an overall minimum by setting the action argument `coverage` and/or setting specific minimums for the different coverage metrics: `coverage-lines`, `coverage-statements`, `coverage-functions` or `coverage-branches`.
 
 ## Example with alternate coverage minimums
 
@@ -75,10 +75,11 @@ There is also an option to adapt the minimum coverage percentage limits that nee
 steps:
   - name: Collect Coverage
     uses: tangro/actions-coverage@1.1.0
+    with:
+      coverage: 94
+      coverage-lines: 96
+      coverage-branches: 92
     env:
-      COVERAGE: 94
-      COVERAGE_LINES: 96
-      COVERAGE_BRANCHES: 92
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       GITHUB_CONTEXT: ${{ toJson(github) }}
 ```

--- a/README.md
+++ b/README.md
@@ -67,6 +67,22 @@ steps:
       GITHUB_CONTEXT: ${{ toJson(github) }}
 ```
 
+There is also an option to adapt the minimum coverage percentage limits that need to be achived for the build to complete successfully. You can configure an overall minimum by setting the environment variable `COVERAGE` and/or setting specific minimums for the different coverage metrics: `COVERAGE_LINES`, `COVERAGE_STATEMENTS`, `COVERAGE_FUNCTIONS` or `COVERAGE_BRANCHES`.
+
+## Example with alternate coverage minimums
+
+```yml
+steps:
+  - name: Collect Coverage
+    uses: tangro/actions-coverage@1.0.0
+    env:
+      COVERAGE: 94
+      COVERAGE_LINES: 96
+      COVERAGE_BRANCHES: 92
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GITHUB_CONTEXT: ${{ toJson(github) }}
+```
+
 ## Development
 
 Follow the guide of the [tangro-actions-template](https://github.com/tangro/tangro-actions-template)

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ jobs:
       - name: Run npm install
         run: npm install
       - name: Collect Coverage
-        uses: tangro/actions-coverage@1.1.0
+        uses: tangro/actions-coverage@1.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_CONTEXT: ${{ toJson(github) }}
@@ -46,7 +46,7 @@ It is also possible that the action posts a comment with the result to the commi
 ```yml
 steps:
   - name: Collect Coverage
-    uses: tangro/actions-coverage@1.1.0
+    uses: tangro/actions-coverage@1.1.1
     with:
       command: 'coverage'
     env:
@@ -59,7 +59,7 @@ steps:
 ```yml
 steps:
   - name: Collect Coverage
-    uses: tangro/actions-coverage@1.1.0
+    uses: tangro/actions-coverage@1.1.1
     with:
       post-comment: true
     env:
@@ -74,7 +74,7 @@ There is also an option to adapt the minimum coverage percentage limits that nee
 ```yml
 steps:
   - name: Collect Coverage
-    uses: tangro/actions-coverage@1.1.0
+    uses: tangro/actions-coverage@1.1.1
     with:
       coverage: 94
       coverage-lines: 96

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ steps:
       GITHUB_CONTEXT: ${{ toJson(github) }}
 ```
 
-There is also an option to adapt the minimum coverage percentage limits that need to be achived for the build to complete successfully (Defaults to `100`). You can configure an overall minimum by setting the environment variable `COVERAGE` and/or setting specific minimums for the different coverage metrics: `COVERAGE_LINES`, `COVERAGE_STATEMENTS`, `COVERAGE_FUNCTIONS` or `COVERAGE_BRANCHES`.
+There is also an option to adapt the minimum coverage percentage limits that need to be achieved for the build to complete successfully (Defaults to `100`). You can configure an overall minimum by setting the environment variable `COVERAGE` and/or setting specific minimums for the different coverage metrics: `COVERAGE_LINES`, `COVERAGE_STATEMENTS`, `COVERAGE_FUNCTIONS` or `COVERAGE_BRANCHES`.
 
 ## Example with alternate coverage minimums
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ jobs:
       - name: Run npm install
         run: npm install
       - name: Collect Coverage
-        uses: tangro/actions-coverage@1.0.0
+        uses: tangro/actions-coverage@1.1.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_CONTEXT: ${{ toJson(github) }}
@@ -46,7 +46,7 @@ It is also possible that the action posts a comment with the result to the commi
 ```yml
 steps:
   - name: Collect Coverage
-    uses: tangro/actions-coverage@1.0.0
+    uses: tangro/actions-coverage@1.1.0
     with:
       command: 'coverage'
     env:
@@ -59,7 +59,7 @@ steps:
 ```yml
 steps:
   - name: Collect Coverage
-    uses: tangro/actions-coverage@1.0.0
+    uses: tangro/actions-coverage@1.1.0
     with:
       post-comment: true
     env:
@@ -67,14 +67,14 @@ steps:
       GITHUB_CONTEXT: ${{ toJson(github) }}
 ```
 
-There is also an option to adapt the minimum coverage percentage limits that need to be achived for the build to complete successfully. You can configure an overall minimum by setting the environment variable `COVERAGE` and/or setting specific minimums for the different coverage metrics: `COVERAGE_LINES`, `COVERAGE_STATEMENTS`, `COVERAGE_FUNCTIONS` or `COVERAGE_BRANCHES`.
+There is also an option to adapt the minimum coverage percentage limits that need to be achived for the build to complete successfully (Defaults to `100`). You can configure an overall minimum by setting the environment variable `COVERAGE` and/or setting specific minimums for the different coverage metrics: `COVERAGE_LINES`, `COVERAGE_STATEMENTS`, `COVERAGE_FUNCTIONS` or `COVERAGE_BRANCHES`.
 
 ## Example with alternate coverage minimums
 
 ```yml
 steps:
   - name: Collect Coverage
-    uses: tangro/actions-coverage@1.0.0
+    uses: tangro/actions-coverage@1.1.0
     env:
       COVERAGE: 94
       COVERAGE_LINES: 96

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "actions-coverage",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "private": true,
   "description": "GitHub Action to run coverage",
   "main": "lib/main.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "actions-coverage",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "private": true,
   "description": "GitHub Action to run coverage",
   "main": "lib/main.js",

--- a/src/coverage.ts
+++ b/src/coverage.ts
@@ -88,7 +88,7 @@ const parseCoverage = (coverageSummary: Coverage): Result<Coverage> => {
 };
 
 const getMinCoveragePct = (type: CoverageType) => {
-  const minValue = parseInt(process.env[`COVERAGE_${type.toUpperCase()}`] || process.env[`COVERAGE`] || '');
+  const minValue = parseInt(core.getInput('coverage-' + type) || core.getInput('coverage') || '');
   return !isNaN(minValue) ? minValue : 100;
 };
 

--- a/src/coverage.ts
+++ b/src/coverage.ts
@@ -33,6 +33,13 @@ interface Coverage {
   };
 }
 
+enum CoverageType {
+  LINES       = 'lines',
+  STATEMENTS  = 'statements',
+  FUNCTIONS   = 'functions',
+  BRANCHES    = 'branches',
+}
+
 const markdownTableCoverage = (coverage: Coverage): string => {
   const formatKey = (k: string) => padEnd(k, 7);
   const formatValue = (v: string) => padStart(v.toString(), 7);
@@ -66,10 +73,10 @@ const parseCoverage = (coverageSummary: Coverage): Result<Coverage> => {
   const { lines, statements, functions, branches } = coverageSummary;
   const shortText = `lns:${lines.pct}% bra:${branches.pct}% fun:${functions.pct}% stm:${statements.pct}%`;
   const isOkay =
-    lines.pct === 100 &&
-    statements.pct === 100 &&
-    functions.pct === 100 &&
-    branches.pct === 100;
+    lines.pct >= getMinCoveragePct(CoverageType.LINES) &&
+    statements.pct >= getMinCoveragePct(CoverageType.STATEMENTS) &&
+    functions.pct >= getMinCoveragePct(CoverageType.FUNCTIONS) &&
+    branches.pct >= getMinCoveragePct(CoverageType.BRANCHES);
   const asMarkdownTable = markdownTableCoverage(coverageSummary);
 
   return {
@@ -78,6 +85,11 @@ const parseCoverage = (coverageSummary: Coverage): Result<Coverage> => {
     shortText,
     text: asMarkdownTable
   };
+};
+
+const getMinCoveragePct = (type: CoverageType) => {
+  const minValue = parseInt(process.env[`COVERAGE_${type.toUpperCase()}`] || process.env[`COVERAGE`] || '');
+  return !isNaN(minValue) ? minValue : 100;
 };
 
 export async function runCoverage({ repo }: { repo: string }) {


### PR DESCRIPTION
This might be helpful to others as well since in our company we do not have a 100% coverage requirement. So we introduced the option to reconfigure these limits (the default still remains at 100).

Besides that I also updated the `release.yml` to match that from the `tangro-actions-template`